### PR TITLE
Add the possibility to use regex for zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,24 @@ environments:
           subzones: true
 ```
 
+
+##### Regex
+
+Under a `zone` the option `regex: true` can be set.
+
+That allows use regex in the zone name.
+
+In this example all zones which end with `.example.com` are allowed.
+
+```YAML
+...
+environments:
+  - name: "Test1"
+    zones:
+     - name: ".*\.example.com"
+       regex: true
+```
+
 #### Global read
 
 Global `read` permissions can be defined under an `environment`.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ In this example all zones which end with `.example.com` are allowed.
 environments:
   - name: "Test1"
     zones:
-     - name: ".*\.example.com"
+     - name: ".*\\.example.com"
        regex: true
 ```
 

--- a/powerdns_api_proxy/config.py
+++ b/powerdns_api_proxy/config.py
@@ -162,23 +162,3 @@ def ensure_rrsets_request_allowed(zone: ProxyConfigZone, request: RRSETRequest) 
             raise HTTPException(403, f'RRSET {rrset["name"]} not allowed')
         logger.info(f'RRSET {rrset["name"]} allowed')
     return True
-
-
-# def get_zone_config(environment: ProxyConfigEnvironment, zone: str) -> ProxyConfigZone:
-#     if not check_pdns_zone_allowed:
-#         raise ZoneNotAllowedException()
-#     for z in environment.zones:
-#         if check_zones_equal(z.name, zone):
-#             return z
-#         elif z.subzones:
-#             if check_subzone(zone, z.name):
-#                 return ProxyConfigZone(
-#                     name=zone,
-#                     subzones=z.subzones,
-#                     services=z.services,
-#                     admin=z.admin,
-#                     all_records=z.all_records,
-#                     records=z.records,
-#                     read_only=z.read_only,
-#                 )
-#     raise ZoneNotAllowedException()

--- a/powerdns_api_proxy/models.py
+++ b/powerdns_api_proxy/models.py
@@ -127,6 +127,12 @@ class ResponseAllowed(BaseModel):
     zones: list[ProxyConfigZone]
 
 
+class ResponseZoneAllowed(BaseModel):
+    zone: str
+    allowed: bool
+    config: ProxyConfigZone | None = None
+
+
 class ZoneNotAllowedException(HTTPException):
     def __init__(self):
         self.status_code = 403

--- a/powerdns_api_proxy/models.py
+++ b/powerdns_api_proxy/models.py
@@ -4,6 +4,11 @@ from fastapi import HTTPException
 from pydantic import BaseModel, field_validator
 
 from powerdns_api_proxy.logging import logger
+from powerdns_api_proxy.utils import (
+    check_subzone,
+    check_zone_in_regex,
+    check_zones_equal,
+)
 
 
 class ProxyConfigServices(BaseModel):
@@ -12,12 +17,16 @@ class ProxyConfigServices(BaseModel):
 
 class ProxyConfigZone(BaseModel):
     '''
+    `name` is the zone name.
+    `regex` should be set to `True` if `name` is a regex.
     `admin` enabled creating and deleting the zone.
     `subzones` sets the same permissions on all subzones.
     `all_records` will be set to `True` if no `records` are defined.
+    `read_only` will be set to `True` if `global_read_only` is `True`.
     '''
 
     name: str
+    regex: bool = False
     description: str = ''
     records: list[str] = []
     services: ProxyConfigServices = ProxyConfigServices(acme=False)
@@ -42,6 +51,7 @@ class ProxyConfigEnvironment(BaseModel):
     zones: list[ProxyConfigZone]
     global_read_only: bool = False
     global_search: bool = False
+    _zones_lookup: dict[str, ProxyConfigZone] = {}
 
     @field_validator('name')
     @classmethod
@@ -65,6 +75,31 @@ class ProxyConfigEnvironment(BaseModel):
             )
             for zone in self.zones:
                 zone.read_only = True
+
+                # populate zones lookup
+                self._zones_lookup[zone.name] = zone
+
+    def get_zone_if_allowed(self, zone: str) -> ProxyConfigZone:
+        '''
+        Returns the zone config for the given zone name
+        Raises ZoneNotAllowedException if the zone is not allowed
+        '''
+        if zone in self._zones_lookup:
+            return self._zones_lookup[zone]
+
+        for z in self.zones:
+            if check_zones_equal(zone, z.name):
+                return z
+
+            if z.subzones and check_subzone(zone, z.name):
+                logger.debug(f'"{zone}" is a subzone of "{z.name}"')
+                return z
+
+            if z.regex and check_zone_in_regex(zone, z.name):
+                logger.debug(f'"{zone}" matches regex "{z.name}"')
+                return z
+
+        raise ZoneNotAllowedException()
 
 
 class ProxyConfig(BaseModel):

--- a/powerdns_api_proxy/proxy.py
+++ b/powerdns_api_proxy/proxy.py
@@ -18,7 +18,6 @@ from powerdns_api_proxy.config import (
     ensure_rrsets_request_allowed,
     get_environment_for_token,
     get_only_pdns_zones_allowed,
-    get_zone_config,
     load_config,
 )
 from powerdns_api_proxy.logging import logger
@@ -316,7 +315,7 @@ async def update_zone_rrset(
     if not check_pdns_zone_allowed(environment, zone_id):
         logger.info(f'Zone {zone_id} not allowed for environment {environment.name}')
         raise ZoneNotAllowedException()
-    zone = get_zone_config(environment, zone_id)
+    zone = environment.get_zone_if_allowed(zone_id)
     ensure_rrsets_request_allowed(zone, await request.json())
     resp = await pdns.patch(
         f'/api/v1/servers/{server_id}/zones/{zone_id}',

--- a/powerdns_api_proxy/utils.py
+++ b/powerdns_api_proxy/utils.py
@@ -1,4 +1,5 @@
 import json
+import re
 from json.decoder import JSONDecodeError
 from typing import Union
 
@@ -12,3 +13,19 @@ async def response_json_or_text(response: ClientResponse) -> Union[dict, str]:
         return json.loads(text)
     except JSONDecodeError:
         return text
+
+
+def check_subzone(zone: str, main_zone: str) -> bool:
+    if zone.rstrip('.').endswith(main_zone.rstrip('.')):
+        return True
+    return False
+
+
+def check_zone_in_regex(zone: str, regex: str) -> bool:
+    '''Checks if zone is in regex'''
+    return re.match(regex, zone.rstrip('.')) is not None
+
+
+def check_zones_equal(zone1: str, zone2: str) -> bool:
+    '''Checks if zones equal with or without trailing dot'''
+    return zone1.rstrip('.') == zone2.rstrip('.')

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,3 @@
+from os import path
+
+FIXTURES_DIR = path.dirname(path.abspath(__file__))

--- a/tests/fixtures/test_regex_parsing.yaml
+++ b/tests/fixtures/test_regex_parsing.yaml
@@ -1,0 +1,4 @@
+---
+# file to test regex parsing with yaml escaping
+name: ".*\\.example\\.com"
+regex: true

--- a/tests/unit/proxy_test.py
+++ b/tests/unit/proxy_test.py
@@ -79,6 +79,7 @@ def _token_missing_request(client: TestClient, method: str, path: str):
 
 get_routes = [
     '/info/allowed',
+    '/info/zone-allowed',
     '/api',
     '/api/v1/servers',
     '/api/v1/servers/localhost',

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -1,0 +1,55 @@
+import pytest
+
+from powerdns_api_proxy.utils import (
+    check_subzone,
+    check_zone_in_regex,
+    check_zones_equal,
+)
+
+
+def test_check_subzone_true():
+    zone = 'myzone.main.example.com'
+    main = 'main.example.com.'
+    assert check_subzone(zone, main)
+
+
+def test_check_subzone_false():
+    zone = 'myzone.test.example.com'
+    main = 'main.example.com.'
+    assert not check_subzone(zone, main)
+
+
+def test_zones_equal_true():
+    zone1 = 'myzone.main.example.com'
+    zone2 = 'myzone.main.example.com.'
+    assert check_zones_equal(zone1, zone2)
+
+
+@pytest.mark.parametrize(
+    'zone, regex',
+    [
+        ('prod.customer.example.com', '.*customer.example.com'),
+        ('dns.prod.customer.example.com.', '.*customer.example.com'),
+        ('prod.customer.example.com.', r'\w+\.customer.example.com'),
+        ('customer.example.com.', r'\w*customer.example.com'),
+        ('prod.customer.example.com.', r'\w+\.\w+\.example.com'),
+    ],
+)
+def test_zones_in_regex_true(zone, regex):
+    assert check_zone_in_regex(zone, regex)
+
+
+@pytest.mark.parametrize(
+    'zone, regex',
+    [
+        ('main.example.com.', r'\w+\.main.example.com'),  # only subzone allowed
+        ('main.example.com.', r'\w+\.main.test.com'),  # false base domain
+        (
+            'subzone.zone.main.example.com.',
+            r'\w+\.main.example.com',
+        ),  # missing dot for subzone
+        ('customer.example.com.', r'main.example.com'),  # only dots
+    ],
+)
+def test_zones_in_regex_false(zone, regex):
+    assert not check_zone_in_regex(zone, regex)

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -1,10 +1,12 @@
 import pytest
+import yaml
 
 from powerdns_api_proxy.utils import (
     check_subzone,
     check_zone_in_regex,
     check_zones_equal,
 )
+from tests.fixtures import FIXTURES_DIR
 
 
 def test_check_subzone_true():
@@ -29,6 +31,7 @@ def test_zones_equal_true():
     'zone, regex',
     [
         ('prod.customer.example.com', '.*customer.example.com'),
+        ('prod.customer.example.com', '.*\\.customer.example.com'),
         ('dns.prod.customer.example.com.', '.*customer.example.com'),
         ('prod.customer.example.com.', r'\w+\.customer.example.com'),
         ('customer.example.com.', r'\w*customer.example.com'),
@@ -53,3 +56,10 @@ def test_zones_in_regex_true(zone, regex):
 )
 def test_zones_in_regex_false(zone, regex):
     assert not check_zone_in_regex(zone, regex)
+
+
+def test_regex_with_parsed_yaml():
+    with open(FIXTURES_DIR + '/test_regex_parsing.yaml') as f:
+        parsed = yaml.safe_load(f)
+    regex_string = parsed['name']
+    assert check_zone_in_regex('customer.example.com.', regex_string)


### PR DESCRIPTION
With this pull request the following configuration is possible:

```yaml
environments:
  - name: "Test1"
    zones:
     - name: ".*\\.example.com"
       regex: true
```

In this example all zones which end with `.example.com` are allowed.