### PR TITLE
feat(metrics): use basic auth instead of api token

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,14 +216,17 @@ metrics_require_auth: false # default is true
 
 When the `metrics_proxy` option is set to `true`, the environment has access to the `/metrics` endpoint of the proxy.
 
-That is needed, when the `metrics_require_auth` option is set to `true` (default).
-
 ```yaml
 ...
 environments:
     - name: "Test1"
       metrics_proxy: true
 ```
+
+When `metrics_require_auth` is enabled, basic auth needs to be used.
+
+* username: name of the environment
+* password: token
 
 #### Metrics
 

--- a/powerdns_api_proxy/models.py
+++ b/powerdns_api_proxy/models.py
@@ -210,7 +210,7 @@ class RessourceNotAllowedException(HTTPException):
 class NotAuthorizedException(HTTPException):
     def __init__(self):
         self.status_code = 401
-        self.detail = 'Not authorized'
+        self.detail = 'Unauthorized'
 
 
 class SearchNotAllowedException(HTTPException):

--- a/powerdns_api_proxy/proxy.py
+++ b/powerdns_api_proxy/proxy.py
@@ -79,11 +79,7 @@ if config.metrics_enabled:
     if config.metrics_require_auth:
         logger.info('Enabling metrics authentication')
         instrumentator.expose(
-            app,
-            dependencies=[
-                Depends(dependency_check_token_defined),
-                Depends(dependency_metrics_proxy_enabled),
-            ],
+            app, dependencies=[Depends(dependency_metrics_proxy_enabled)]
         )
     else:
         instrumentator.expose(app)


### PR DESCRIPTION
prometheus cannot use headers, so we use basic auth 