### PR TITLE
allow records with regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ environments:
            - "test.example.com"
 ```
 
+###### Regex
+
+Additionally to the `records` list a `regex_records` list can be defined.
+In this list regex can be to define, which records are allowed.
+
+```yaml
+...
+environments:
+    - name: "Test1"
+      ...
+      zones:
+       - name: "example.com"
+         regex_records:
+           - "_acme-challenge.service-.*.example.com"
+```
+
 ##### Services
 
 Under a `zone` `services` can be defined.

--- a/powerdns_api_proxy/models.py
+++ b/powerdns_api_proxy/models.py
@@ -19,7 +19,10 @@ class ProxyConfigServices(BaseModel):
 class ProxyConfigZone(BaseModel):
     '''
     `name` is the zone name.
+    `description` is a description of the zone.
     `regex` should be set to `True` if `name` is a regex.
+    `records` is a list of record names that are allowed.
+    `regex_records` is a list of record regexes that are allowed.
     `admin` enabled creating and deleting the zone.
     `subzones` sets the same permissions on all subzones.
     `all_records` will be set to `True` if no `records` are defined.
@@ -30,6 +33,7 @@ class ProxyConfigZone(BaseModel):
     regex: bool = False
     description: str = ''
     records: list[str] = []
+    regex_records: list[str] = []
     services: ProxyConfigServices = ProxyConfigServices(acme=False)
     admin: bool = False
     subzones: bool = False
@@ -38,7 +42,7 @@ class ProxyConfigZone(BaseModel):
 
     def __init__(self, **data):
         super().__init__(**data)
-        if len(self.records) == 0:
+        if len(self.records) == 0 and len(self.regex_records) == 0:
             logger.debug(
                 f'Setting all_records to True for zone {self.name}, because no records are defined'
             )

--- a/powerdns_api_proxy/utils.py
+++ b/powerdns_api_proxy/utils.py
@@ -26,6 +26,11 @@ def check_zone_in_regex(zone: str, regex: str) -> bool:
     return re.match(regex, zone.rstrip('.')) is not None
 
 
+def check_record_in_regex(record: str, regex: str) -> bool:
+    '''Checks if record is in regex'''
+    return re.match(regex, record.rstrip('.')) is not None
+
+
 def check_zones_equal(zone1: str, zone2: str) -> bool:
     '''Checks if zones equal with or without trailing dot'''
     return zone1.rstrip('.') == zone2.rstrip('.')


### PR DESCRIPTION
We want to allow the usage of regex to avoid too many records like
service1.test.local, service2.test.local, service3.test.local .... and instead allow `service\d+.test.local`