### PR TITLE
fix: disable connector_owner

### DIFF
--- a/powerdns_api_proxy/pdns.py
+++ b/powerdns_api_proxy/pdns.py
@@ -21,7 +21,9 @@ class PDNSConnector:
             f"params: {params}, payload: {payload}"
         )
         async with aiohttp.ClientSession(
-            base_url=self.base_url, headers=self.headers
+            base_url=self.base_url,
+            headers=self.headers,
+            connector_owner=False,
         ) as session:
             async with session.request(
                 method,


### PR DESCRIPTION
Solve "RuntimeError: Session is closed" after every request following the first by allowing aiohttp to utilize the same connection pool repeatedly. An alternative would be to initialize a new backend session for every request.