### PR TITLE
fix: allow empty zones field

### DIFF
--- a/powerdns_api_proxy/models.py
+++ b/powerdns_api_proxy/models.py
@@ -1,7 +1,7 @@
 from functools import lru_cache
 from typing import TypedDict
 
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, field_validator
 
 from powerdns_api_proxy.logging import logger
 from powerdns_api_proxy.utils import (
@@ -76,14 +76,6 @@ class ProxyConfigEnvironment(BaseModel):
         if len(token_sha512) != 128:
             raise ValueError("A SHA512 hash must be 128 digits long")
         return token_sha512
-
-    @model_validator(mode="after")
-    def validate_zones_or_global_read_only(self):
-        if not self.zones and not self.global_read_only:
-            raise ValueError(
-                "Either 'zones' must be non-empty or 'global_read_only' must be True"
-            )
-        return self
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -629,26 +629,15 @@ def test_global_read_only_without_zones():
     assert env.zones == []
 
 
-def test_environment_with_neither_zones_nor_global_read_only_fails():
-    """Test that providing neither zones nor global_read_only fails validation"""
-    with pytest.raises(ValueError) as err:
-        ProxyConfigEnvironment(
-            name="test", token_sha512=dummy_proxy_environment_token_sha512
-        )
-    assert "Either 'zones' must be non-empty or 'global_read_only' must be True" in str(
-        err.value
+def test_environment_with_empty_zones_denies_zone_access():
+    """Test that environment with empty zones and no global permissions denies zone access"""
+    env = ProxyConfigEnvironment(
+        name="test",
+        token_sha512=dummy_proxy_environment_token_sha512,
+        zones=[],
     )
-
-
-def test_environment_with_empty_zones_and_no_global_read_only_fails():
-    """Test that explicitly providing empty zones without global_read_only fails"""
-    with pytest.raises(ValueError) as err:
-        ProxyConfigEnvironment(
-            name="test", token_sha512=dummy_proxy_environment_token_sha512, zones=[]
-        )
-    assert "Either 'zones' must be non-empty or 'global_read_only' must be True" in str(
-        err.value
-    )
+    assert not check_pdns_zone_allowed(env, "test.example.com.")
+    assert not check_pdns_zone_allowed(env, "any.zone.com.")
 
 
 def test_proxy_config_with_global_read_only_environment():


### PR DESCRIPTION
I don't know why we made it this way. We would need to put all global permission in this condition...

> "Either 'zones' must be non-empty or 'global_read_only' must be True"


If the zones are empty, there just should be no permission on any zone.