### PR TITLE
fix: skip endswith guard for regex zones in check_rrset_allowed

### DIFF
--- a/powerdns_api_proxy/config.py
+++ b/powerdns_api_proxy/config.py
@@ -155,7 +155,7 @@ def check_rrset_allowed(zone: ProxyConfigZone, rrset: RRSET) -> bool:
     if zone.all_records:
         return True
 
-    if not rrset["name"].rstrip(".").endswith(zone.name.rstrip(".")):
+    if not zone.regex and not rrset["name"].rstrip(".").endswith(zone.name.rstrip(".")):
         logger.debug("RRSET not allowed, because zone does not match")
         return False
 


### PR DESCRIPTION
When zone.regex is True, zone.name is a pattern like '.*' rather than a real DNS name. The endswith guard was always False for these zones, causing regex_records to never be evaluated and all writes to be denied.

Without this change my configuration doesn't work:


```
  - name: myapp
    token_sha512: >-
      secret
    global_read_only: true
    zones:
      - name: ".*"
        regex: true
        allowed_record_types:
          - "TXT"
          - "CNAME"
        regex_records:
        - "^_.*"
```

This configuration only allows `myapp` to touch TXT and CNAME records starting with an _.

Fixes akquinet/powerdns-api-proxy#196