### PR TITLE
correct the default listen to also use ipv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ index_html: |
 ```bash
 LOG_LEVEL=DEBUG       # Optional: DEBUG, INFO, WARNING, ERROR (default: DEBUG)
 LOG_FORMAT=json       # Optional: "text" (default) or "json" for structured logging
-LISTEN_HOST=0.0.0.0   # Optional: Host to bind to (default: 0.0.0.0)
+LISTEN_HOST=0.0.0.0   # Optional: Host to bind to (default: *)
 LISTEN_PORT=8000      # Optional: Port to listen on (default: 8000)
 ```
 

--- a/powerdns_api_proxy/__main__.py
+++ b/powerdns_api_proxy/__main__.py
@@ -5,7 +5,7 @@ from powerdns_api_proxy.uvicorn_config import LOGGING_CONFIG
 
 
 def main() -> int:
-    host = os.getenv("LISTEN_HOST", "0.0.0.0")
+    host = os.getenv("LISTEN_HOST", "*")
     port = int(os.getenv("LISTEN_PORT", "8000"))
     reload = "--reload" in sys.argv
 


### PR DESCRIPTION
With #199 we needed to change the logging config of uvicorn to suport json output.  
To do that we changed the way we start uvicorn and accidentally the listen config from `*` to `0.0.0.0`.

This PR changes it back.

```bash
❯ python -m powerdns_api_proxy
...
INFO:     Started server process [30577]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://*:8000 (Press CTRL+C to quit)
```

```bash
❯ ss -tulpn | grep 8000
tcp   LISTEN 0      2048               0.0.0.0:8000       0.0.0.0:*    users:(("python",pid=30577,fd=8))
tcp   LISTEN 0      2048                  [::]:8000          [::]:*    users:(("python",pid=30577,fd=7))
```