### PR TITLE
Log File configurable & log error instead of crashing on missing permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,11 +324,11 @@ index_html: |
 ### Environment Variables
 
 ```bash
-LOG_LEVEL=DEBUG       # Optional: DEBUG, INFO, WARNING, ERROR (default: DEBUG)
-LOG_FORMAT=json       # Optional: "text" (default) or "json" for structured logging
-LOG_FILE=/var/log/app.log  # Optional: Enable file logging to specified path (default: disabled, logs to stderr only)
-LISTEN_HOST=0.0.0.0   # Optional: Host to bind to (default: *)
-LISTEN_PORT=8000      # Optional: Port to listen on (default: 8000)
+LOG_LEVEL=DEBUG            # Optional: DEBUG, INFO, WARNING, ERROR (default: DEBUG)
+LOG_FORMAT=json            # Optional: "text" (default) or "json" for structured logging
+LOG_FILE=/var/log/app.log  # Optional: Log file path (default: "log"), set to "false" to disable file logging
+LISTEN_HOST=0.0.0.0        # Optional: Host to bind to (default: *)
+LISTEN_PORT=8000           # Optional: Port to listen on (default: 8000)
 ```
 
 When `LOG_FORMAT=json` is set, all logs (application and uvicorn access logs) will be output in JSON format.

--- a/powerdns_api_proxy/logging.py
+++ b/powerdns_api_proxy/logging.py
@@ -99,13 +99,16 @@ default_stream_handler.setFormatter(default_formatter)
 logger: AuditLogger = logging.getLogger("powerdns_api_proxy")  # type: ignore
 logger.addHandler(default_stream_handler)
 
-LOG_FILE = getenv("LOG_FILE")
-if LOG_FILE:
-    file_handler = logging.handlers.RotatingFileHandler(
-        filename=LOG_FILE, maxBytes=1000**2 * 100, backupCount=5
-    )
-    file_handler.setLevel("DEBUG")
-    file_handler.setFormatter(default_formatter)
-    logger.addHandler(file_handler)
+LOG_FILE = getenv("LOG_FILE", "log")
+if LOG_FILE and LOG_FILE.lower() != "false":
+    try:
+        file_handler = logging.handlers.RotatingFileHandler(
+            filename=LOG_FILE, maxBytes=1000**2 * 100, backupCount=5
+        )
+        file_handler.setLevel(LOG_LEVEL)
+        file_handler.setFormatter(default_formatter)
+        logger.addHandler(file_handler)
+    except OSError as e:
+        logger.error(f"Failed to enable file logging to {LOG_FILE}: {e}")
 
 logger.setLevel("DEBUG")


### PR DESCRIPTION
Closes #205 

The following is now possible:

```bash
# Change log file location
LOG_FILE="/var/pdns-proxy.log"

# deactivate log file
LOG_FILE=false
```

On missing permissions for the file an error is logged, but the app still starts.

I would like to deactivate the log to file functionality entirely as default, but that would be a breaking change.

Maybe if we do a v2 someday.  