### PR TITLE
fix: security issues with regex and subzone parsing

### DIFF
--- a/powerdns_api_proxy/config.py
+++ b/powerdns_api_proxy/config.py
@@ -21,7 +21,11 @@ from powerdns_api_proxy.models import (
     ProxyConfigZone,
     RRSETRequest,
 )
-from powerdns_api_proxy.utils import check_record_in_regex, check_zones_equal
+from powerdns_api_proxy.utils import (
+    check_record_in_regex,
+    check_subzone,
+    check_zones_equal,
+)
 
 
 @lru_cache(maxsize=1)
@@ -157,7 +161,11 @@ def check_rrset_allowed(zone: ProxyConfigZone, rrset: RRSET) -> bool:
     if zone.all_records:
         return True
 
-    if not zone.regex and not rrset["name"].rstrip(".").endswith(zone.name.rstrip(".")):
+    if (
+        not zone.regex
+        and not check_zones_equal(rrset["name"], zone.name)
+        and not check_subzone(rrset["name"], zone.name)
+    ):
         logger.debug("RRSET not allowed, because zone does not match")
         return False
 

--- a/powerdns_api_proxy/utils.py
+++ b/powerdns_api_proxy/utils.py
@@ -2,19 +2,20 @@ import re
 
 
 def check_subzone(zone: str, main_zone: str) -> bool:
-    if zone.rstrip(".").endswith(main_zone.rstrip(".")):
-        return True
-    return False
+    """Checks if `zone` is a subzone of `main_zone` (or equal to it)."""
+    zone = zone.rstrip(".")
+    main_zone = main_zone.rstrip(".")
+    return zone == main_zone or zone.endswith("." + main_zone)
 
 
 def check_zone_in_regex(zone: str, regex: str) -> bool:
-    """Checks if zone is in regex"""
-    return re.match(regex, zone.rstrip(".")) is not None
+    """Checks if zone fully matches regex"""
+    return re.fullmatch(regex, zone.rstrip(".")) is not None
 
 
 def check_record_in_regex(record: str, regex: str) -> bool:
-    """Checks if record is in regex"""
-    return re.match(regex, record.rstrip(".")) is not None
+    """Checks if record fully matches regex"""
+    return re.fullmatch(regex, record.rstrip(".")) is not None
 
 
 def check_zones_equal(zone1: str, zone2: str) -> bool:

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -4,6 +4,7 @@ import yaml
 from powerdns_api_proxy.utils import (
     check_subzone,
     check_zone_in_regex,
+    check_record_in_regex,
     check_zones_equal,
 )
 from tests.fixtures import FIXTURES_DIR
@@ -19,6 +20,18 @@ def test_check_subzone_false():
     zone = "myzone.test.example.com"
     main = "main.example.com."
     assert not check_subzone(zone, main)
+
+
+def test_check_subzone_false_suffix_not_subdomain():
+    """Suffix match without dot boundary must be rejected"""
+    assert not check_subzone("evilexample.com", "example.com")
+    assert not check_subzone("notexample.com.", "example.com.")
+
+
+def test_check_subzone_true_exact_match():
+    """Exact matches should be considered valid"""
+    assert check_subzone("example.com", "example.com.")
+    assert check_subzone("example.com.", "example.com")
 
 
 def test_zones_equal_true():
@@ -56,6 +69,30 @@ def test_zones_in_regex_true(zone, regex):
 )
 def test_zones_in_regex_false(zone, regex):
     assert not check_zone_in_regex(zone, regex)
+
+
+def test_zone_in_regex_false_unanchored_suffix():
+    """Regex must not match zones with trailing attacker-controlled content"""
+    assert not check_zone_in_regex("evil.example.com.attacker.com", r".*\.example\.com")
+    assert not check_zone_in_regex("example.com.attacker.net", r"example\.com")
+
+
+def test_record_in_regex_false_unanchored_suffix():
+    """Regex must not match records with trailing attacker-controlled content"""
+    assert not check_record_in_regex(
+        "_acme-challenge.service-test.example.com.attacker.net",
+        r"_acme-challenge\.service-.*\.example\.com",
+    )
+    assert not check_record_in_regex("test.example.comEVIL", r"test\.example\.com")
+
+
+def test_record_in_regex_true_valid_matches():
+    """Valid record regex matches should work"""
+    assert check_record_in_regex(
+        "_acme-challenge.service-test.example.com",
+        r"_acme-challenge\.service-.*\.example\.com",
+    )
+    assert check_record_in_regex("service-42.example.com", r"service-\d+\.example\.com")
 
 
 def test_regex_with_parsed_yaml():


### PR DESCRIPTION
Fix regex and subzone matching to prevent suffix attacks and unanchored regex patterns in zone and record validation.

Related to #215