### PR TITLE
fix: do not log TSIG and DNSSEC key material

### DIFF
--- a/powerdns_api_proxy/pdns.py
+++ b/powerdns_api_proxy/pdns.py
@@ -96,9 +96,12 @@ class PDNSConnector:
     async def request(
         self, method: str, path: str, params: dict = {}, payload: dict = {}
     ):
+        # Avoid leaking secret material (DNSSEC private keys, TSIG keys) into logs.
+        is_sensitive_path = any(s in path for s in ("/cryptokeys", "/tsigkeys"))
+        logged_payload = "<redacted>" if is_sensitive_path and payload else payload
         logger.info(
             f"Getting upstream PDNS API with method: {method}, path: {self.base_url + path}, "
-            f"params: {params}, payload: {payload}"
+            f"params: {params}, payload: {logged_payload}"
         )
 
         async with aiohttp.ClientSession(
@@ -112,8 +115,9 @@ class PDNSConnector:
                 verify_ssl=self.verify_ssl,
             ) as req:
                 text = await req.text()
+                logged_text = "<redacted>" if is_sensitive_path else text
                 logger.debug(
-                    f'Got answer from upstream PDNS API Status: {req.status}, text: "{text}"'
+                    f'Got answer from upstream PDNS API Status: {req.status}, text: "{logged_text}"'
                 )
                 return req
 

--- a/tests/unit/pdns_test.py
+++ b/tests/unit/pdns_test.py
@@ -1,0 +1,81 @@
+import asyncio
+import logging
+from unittest.mock import patch
+
+from powerdns_api_proxy.pdns import PDNSConnector
+
+
+class _AsyncContextManager:
+    """Minimal async context manager yielding a fixed value."""
+
+    def __init__(self, value):
+        self._value = value
+
+    async def __aenter__(self):
+        return self._value
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class _FakeResponse:
+    def __init__(self, text: str, status: int = 200):
+        self.status = status
+        self._text = text
+
+    async def text(self) -> str:
+        return self._text
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeResponse):
+        self._response = response
+
+    def request(self, *args, **kwargs):
+        return _AsyncContextManager(self._response)
+
+
+def _run_request(path: str, payload: dict, response_text: str):
+    connector = PDNSConnector("http://pdns.example", "upstream-token")
+    session = _FakeSession(_FakeResponse(response_text))
+    with patch(
+        "powerdns_api_proxy.pdns.aiohttp.ClientSession",
+        return_value=_AsyncContextManager(session),
+    ):
+        asyncio.run(connector.request("POST", path, payload=payload))
+
+
+def test_tsigkey_payload_is_not_logged(caplog):
+    """The secret of a TSIG key must not end up in the logs"""
+    with caplog.at_level(logging.DEBUG, logger="powerdns_api_proxy"):
+        _run_request(
+            "/api/v1/servers/localhost/tsigkeys",
+            {"name": "test", "key": "SUPER_SECRET_TSIG_KEY"},
+            '{"key": "SUPER_SECRET_TSIG_KEY"}',
+        )
+    assert "SUPER_SECRET_TSIG_KEY" not in caplog.text
+    assert "<redacted>" in caplog.text
+
+
+def test_cryptokey_response_is_not_logged(caplog):
+    """The private key of a CryptoKey must not end up in the logs"""
+    with caplog.at_level(logging.DEBUG, logger="powerdns_api_proxy"):
+        _run_request(
+            "/api/v1/servers/localhost/zones/example.com./cryptokeys/1",
+            {},
+            '{"privatekey": "SUPER_SECRET_PRIVATE_KEY"}',
+        )
+    assert "SUPER_SECRET_PRIVATE_KEY" not in caplog.text
+    assert "<redacted>" in caplog.text
+
+
+def test_other_paths_are_still_logged(caplog):
+    """Requests without key material keep their previous log output"""
+    with caplog.at_level(logging.DEBUG, logger="powerdns_api_proxy"):
+        _run_request(
+            "/api/v1/servers/localhost/zones/example.com.",
+            {"rrsets": [{"name": "test.example.com."}]},
+            '{"name": "example.com."}',
+        )
+    assert "test.example.com." in caplog.text
+    assert "<redacted>" not in caplog.text


### PR DESCRIPTION
PDNSConnector.request() logged the full request payload at INFO level and the full response body at DEBUG level for every upstream call, without any redaction. Creating or updating a TSIG key therefore wrote its secret to the logs, and reading a CryptoKey wrote the DNSSEC private key, since that endpoint returns it.

With the default settings this is also persisted to disk, because LOG_LEVEL defaults to DEBUG and file logging is enabled. As the payload was logged at INFO, raising the log level did not avoid it either.

The audit logger already skips payloads for /cryptokeys and /tsigkeys. The same paths are now redacted in the connector, so the two are consistent.

Operators who have used these endpoints may want to purge existing logs and rotate the affected keys.