### PR TITLE
feat: log client IP in audit log

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,11 +366,19 @@ LOG_FORMAT=json            # Optional: "text" (default) or "json" for structured
 LOG_FILE=/var/log/app.log  # Optional: Log file path (default: "log"), set to "false" to disable file logging
 LISTEN_HOST=0.0.0.0        # Optional: Host to bind to (default: *)
 LISTEN_PORT=8000           # Optional: Port to listen on (default: 8000)
+AUDIT_LOGGING=true         # Optional: set to "false" to disable audit logging (default: true)
+AUDIT_LOG_CLIENT_IP=true   # Optional: set to "false" to omit client IPs from audit logs (default: true)
+FORWARDED_ALLOW_IPS=127.0.0.1  # Optional: peers trusted to set X-Forwarded-For (default: 127.0.0.1)
 ```
 
 When `LOG_FORMAT=json` is set, all logs (application and uvicorn access logs) will be output in JSON format.
 
 Set `AUDIT_LOGGING=false` to disable automatic audit logging of API requests.
+
+Set `AUDIT_LOG_CLIENT_IP=false` to omit client IP addresses from audit logs while
+keeping the rest of the audit trail. Note that this does not affect the uvicorn
+access log, which logs the client address independently; to suppress IPs entirely,
+raise the log level of the `uvicorn.access` logger as well.
 
 ### Audit Logging
 
@@ -385,6 +393,7 @@ Each audit log entry contains:
 - `event_type`: "audit" for easy filtering
 - `audit`: Structured audit data object containing:
   - `environment`: Name of the authenticated environment/token
+  - `client_ip`: IP address of the client that made the request (omitted if `AUDIT_LOG_CLIENT_IP=false`, or if the peer address is unavailable). See [Running Behind a Reverse Proxy](#running-behind-a-reverse-proxy-tls-sidecar).
   - `method`: HTTP method (GET, POST, PUT, PATCH, DELETE)
   - `path`: Resource path that was accessed/modified
   - `status_code`: HTTP response status code
@@ -394,15 +403,15 @@ Each audit log entry contains:
 #### Text Format (default)
 
 ```
-INFO - 2026-03-26 12:03:21,323 - powerdns_api_proxy - proxy.py - audit - 70 - AUDIT: Test1 PATCH /zones/example.com 204 payload={'rrsets': []}
-INFO - 2026-03-26 12:03:21,323 - powerdns_api_proxy - proxy.py - audit - 70 - AUDIT: Test1 GET /zones 200 query_params={'rrsets': 'true'}
-INFO - 2026-03-26 12:03:21,323 - powerdns_api_proxy - proxy.py - audit - 70 - AUDIT: Test1 DELETE /zones/test.com 403
+INFO - 2026-03-26 12:03:21,323 - powerdns_api_proxy - proxy.py - audit - 70 - AUDIT: Test1 203.0.113.9 PATCH /zones/example.com 204 payload={'rrsets': []}
+INFO - 2026-03-26 12:03:21,323 - powerdns_api_proxy - proxy.py - audit - 70 - AUDIT: Test1 203.0.113.9 GET /zones 200 query_params={'rrsets': 'true'}
+INFO - 2026-03-26 12:03:21,323 - powerdns_api_proxy - proxy.py - audit - 70 - AUDIT: Test1 203.0.113.9 DELETE /zones/test.com 403
 ```
 
 #### JSON Format (set LOG_FORMAT=json)
 
 ```json
-{"timestamp": "2026-03-26T11:39:29", "level": "INFO", "event_type": "audit", "audit": {"environment": "Test1", "method": "PATCH", "path": "/zones/example.com", "status_code": 204, "payload": {"rrsets": [...]}}}
+{"timestamp": "2026-03-26T11:39:29", "level": "INFO", "event_type": "audit", "audit": {"environment": "Test1", "client_ip": "203.0.113.9", "method": "PATCH", "path": "/zones/example.com", "status_code": 204, "payload": {"rrsets": [...]}}}
 ```
 
 #### Analyzing Audit Logs
@@ -427,7 +436,59 @@ docker logs powerdns-api-proxy 2>&1 | jq 'select(.event_type == "audit") | {time
 
 # Show failed attempts (403)
 docker logs powerdns-api-proxy 2>&1 | jq 'select(.event_type == "audit" and .audit.status_code == 403)'
+
+# Filter by client IP
+docker logs powerdns-api-proxy 2>&1 | jq 'select(.event_type == "audit" and .audit.client_ip == "203.0.113.9")'
+
+# Rank clients by number of write operations
+docker logs powerdns-api-proxy 2>&1 | jq -r 'select(.event_type == "audit" and (.audit.method != "GET")) | .audit.client_ip' | sort | uniq -c | sort -rn
 ```
+
+### Running Behind a Reverse Proxy (TLS Sidecar)
+
+`X-Forwarded-For` is trusted only when it comes from a peer listed in
+`FORWARDED_ALLOW_IPS` (default: `127.0.0.1`). When it is trusted, the address it
+carries becomes the `client_ip` in the audit log and the client address in the
+uvicorn access log. When it is not trusted, the header is ignored and the real
+TCP peer is logged instead.
+
+A TLS-terminating nginx sidecar that shares the pod's network namespace connects
+over loopback, so **the default needs no configuration**. Set
+`FORWARDED_ALLOW_IPS` only when the proxy sees a non-loopback peer:
+
+```bash
+FORWARDED_ALLOW_IPS=10.244.0.0/16      # CIDR ranges are supported
+FORWARDED_ALLOW_IPS=10.0.0.7,10.0.0.8  # or a comma-separated list of hosts
+```
+
+Avoid `FORWARDED_ALLOW_IPS=*`. It trusts every peer and takes the left-most
+`X-Forwarded-For` entry verbatim, which lets any client forge the `client_ip`
+recorded against its own requests.
+
+Minimal nginx configuration:
+
+```nginx
+location / {
+    proxy_pass http://127.0.0.1:8000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+```
+
+Note that `$proxy_add_x_forwarded_for` *appends* to whatever `X-Forwarded-For`
+the client sent. That is correct for an nginx sitting behind another proxy, but
+if this nginx is the edge that clients reach directly, a client can prepend a
+forged hop. Overwrite the header at the edge instead:
+
+```nginx
+proxy_set_header X-Forwarded-For $remote_addr;
+```
+
+With several hops, list every intermediate proxy in `FORWARDED_ALLOW_IPS`. The
+chain is walked from right to left and the first untrusted entry is taken as the
+client, so a proxy missing from the list gets logged in place of the real
+client.
 
 ## Development
 

--- a/powerdns_api_proxy/__main__.py
+++ b/powerdns_api_proxy/__main__.py
@@ -9,12 +9,19 @@ def main() -> int:
     port = int(os.getenv("LISTEN_PORT", "8000"))
     reload = "--reload" in sys.argv
 
+    # Passed explicitly rather than relying on uvicorn's defaults: this is the
+    # trust boundary that decides whether X-Forwarded-For is honoured, so it
+    # should not silently change under us on a dependency bump.
+    forwarded_allow_ips = os.getenv("FORWARDED_ALLOW_IPS", "127.0.0.1")
+
     uvicorn.run(
         "powerdns_api_proxy.proxy:app",
         host=host,
         port=port,
         log_config=LOGGING_CONFIG,
         reload=reload,
+        proxy_headers=True,
+        forwarded_allow_ips=forwarded_allow_ips,
     )
     return 0
 

--- a/powerdns_api_proxy/logging.py
+++ b/powerdns_api_proxy/logging.py
@@ -52,6 +52,7 @@ class AuditLogger(logging.Logger):
         status_code: int,
         payload: dict | None = None,
         query_params: dict | None = None,
+        client_ip: str | None = None,
     ):
         """Log audit events with structured data"""
         # Skip payload logging for sensitive endpoints
@@ -60,8 +61,10 @@ class AuditLogger(logging.Logger):
         ):
             payload = None
 
-        audit_data = {
+        audit_data: dict[str, str | int | dict] = {
             "environment": environment,
+            # Reported next to the identity it belongs to
+            **({"client_ip": client_ip} if client_ip else {}),
             "method": method,
             "path": path,
             "status_code": status_code,
@@ -72,7 +75,8 @@ class AuditLogger(logging.Logger):
             audit_data["query_params"] = query_params
 
         # Build message with optional query_params/payload info
-        msg_parts = [f"AUDIT: {environment} {method} {path} {status_code}"]
+        identity = f"{environment} {client_ip}" if client_ip else environment
+        msg_parts = [f"AUDIT: {identity} {method} {path} {status_code}"]
         if query_params:
             msg_parts.append(f"query_params={query_params}")
         if payload is not None:

--- a/powerdns_api_proxy/middleware.py
+++ b/powerdns_api_proxy/middleware.py
@@ -42,6 +42,13 @@ class AuditMiddleware(BaseHTTPMiddleware):
 
         query_params = dict(request.query_params) if request.query_params else None
 
+        # Reflects X-Forwarded-For when uvicorn's proxy_headers trusts the
+        # immediate peer -- see FORWARDED_ALLOW_IPS in the README. request.client
+        # is None on transports that omit "client" from the ASGI scope.
+        client_ip = None
+        if os.getenv("AUDIT_LOG_CLIENT_IP", "true").lower() != "false":
+            client_ip = request.client.host if request.client else None
+
         path = request.url.path.replace("/api/v1/servers/localhost", "")
         status_code = 500
         try:
@@ -63,4 +70,5 @@ class AuditMiddleware(BaseHTTPMiddleware):
                 status_code,
                 payload,
                 query_params,
+                client_ip,
             )

--- a/tests/unit/logging_test.py
+++ b/tests/unit/logging_test.py
@@ -134,3 +134,68 @@ def test_audit_log_skips_tsigkeys_payloads(caplog):
     record = caplog.records[0]
     assert record.message == "AUDIT: Test1 PUT /tsigkeys/key1 200"
     assert "payload" not in record.audit
+
+
+def test_audit_log_text_format_with_client_ip(caplog):
+    logger = logging.getLogger("test_audit_client_ip_text")
+    logger.setLevel(logging.INFO)
+    logger.__class__ = AuditLogger
+
+    with caplog.at_level(logging.INFO, logger="test_audit_client_ip_text"):
+        logger.audit("Test1", "DELETE", "/zones/test.com", 403, client_ip="203.0.113.9")
+
+    record = caplog.records[0]
+    assert record.message == "AUDIT: Test1 203.0.113.9 DELETE /zones/test.com 403"
+    assert record.audit["client_ip"] == "203.0.113.9"
+
+
+def test_audit_log_text_format_client_ip_precedes_optional_extras(caplog):
+    logger = logging.getLogger("test_audit_client_ip_extras")
+    logger.setLevel(logging.INFO)
+    logger.__class__ = AuditLogger
+
+    with caplog.at_level(logging.INFO, logger="test_audit_client_ip_extras"):
+        logger.audit(
+            "Test1",
+            "PATCH",
+            "/zones/example.com",
+            204,
+            {"rrsets": []},
+            client_ip="203.0.113.9",
+        )
+
+    record = caplog.records[0]
+    assert record.message == (
+        "AUDIT: Test1 203.0.113.9 PATCH /zones/example.com 204 payload={'rrsets': []}"
+    )
+
+
+def test_audit_log_json_format_with_client_ip(json_logger):
+    logger, stream = json_logger
+
+    logger.audit("Test1", "PATCH", "/zones/example.com", 204, client_ip="203.0.113.9")
+    log_data = json.loads(stream.getvalue())
+
+    assert log_data["audit"] == {
+        "environment": "Test1",
+        "client_ip": "203.0.113.9",
+        "method": "PATCH",
+        "path": "/zones/example.com",
+        "status_code": 204,
+    }
+    # client_ip is reported next to the identity it belongs to
+    assert list(log_data["audit"])[:2] == ["environment", "client_ip"]
+
+
+def test_audit_log_omits_client_ip_when_not_provided(caplog):
+    """Regression guard: existing callers and log parsers must be unaffected."""
+    logger = logging.getLogger("test_audit_client_ip_absent")
+    logger.setLevel(logging.INFO)
+    logger.__class__ = AuditLogger
+
+    with caplog.at_level(logging.INFO, logger="test_audit_client_ip_absent"):
+        logger.audit("Test1", "DELETE", "/zones/test.com", 403)
+
+    record = caplog.records[0]
+    assert record.message == "AUDIT: Test1 DELETE /zones/test.com 403"
+    assert "client_ip" not in record.audit

--- a/tests/unit/main_test.py
+++ b/tests/unit/main_test.py
@@ -1,0 +1,32 @@
+import uvicorn
+
+from powerdns_api_proxy.__main__ import main
+
+
+def _captured_uvicorn_kwargs(monkeypatch):
+    captured: dict = {}
+
+    def fake_run(app, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(uvicorn, "run", fake_run)
+    main()
+    return captured
+
+
+def test_main_enables_proxy_headers_explicitly(monkeypatch):
+    """The trust boundary must live in our code, not in a uvicorn default."""
+    monkeypatch.delenv("FORWARDED_ALLOW_IPS", raising=False)
+
+    captured = _captured_uvicorn_kwargs(monkeypatch)
+
+    assert captured["proxy_headers"] is True
+    assert captured["forwarded_allow_ips"] == "127.0.0.1"
+
+
+def test_main_reads_forwarded_allow_ips_from_env(monkeypatch):
+    monkeypatch.setenv("FORWARDED_ALLOW_IPS", "10.244.0.0/16")
+
+    captured = _captured_uvicorn_kwargs(monkeypatch)
+
+    assert captured["forwarded_allow_ips"] == "10.244.0.0/16"

--- a/tests/unit/middleware_test.py
+++ b/tests/unit/middleware_test.py
@@ -1,7 +1,14 @@
+import os
+
+import anyio
 import pytest
 from fastapi.testclient import TestClient
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
-from powerdns_api_proxy.proxy import app
+# Must be set before importing the proxy, which loads the config at import time
+os.environ["PROXY_CONFIG_PATH"] = "./config-example.yml"
+
+from powerdns_api_proxy.proxy import app  # noqa: E402
 
 
 @pytest.fixture
@@ -53,3 +60,99 @@ def test_middleware_logs_query_params(client, caplog):
 
     audit = audit_records[0].audit
     assert audit["query_params"] == {"rrsets": "true"}
+
+
+def _audit_record(caplog):
+    audit_records = [r for r in caplog.records if hasattr(r, "audit")]
+    assert len(audit_records) > 0
+    return audit_records[0].audit
+
+
+def _asgi_get_without_client(target_app, path):
+    """Invoke the ASGI app directly with no ``client`` key in the scope.
+
+    Some ASGI transports (e.g. unix sockets) omit it, which makes
+    ``request.client`` None.
+    """
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(b"host", b"testserver"), (b"x-api-key", b"invalid")],
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        pass
+
+    anyio.run(target_app, scope, receive, send)
+
+
+def test_middleware_logs_client_ip(client, caplog):
+    client.get(
+        "/api/v1/servers/localhost/zones",
+        headers={"X-API-Key": "invalid"},
+    )
+
+    # TestClient's default peer address
+    assert _audit_record(caplog)["client_ip"] == "testclient"
+
+
+def test_middleware_logs_forwarded_client_ip(caplog):
+    """The nginx-sidecar path: uvicorn rewrites the peer from X-Forwarded-For."""
+    proxied_app = ProxyHeadersMiddleware(app, trusted_hosts="testclient")
+    proxied_client = TestClient(proxied_app)
+
+    proxied_client.get(
+        "/api/v1/servers/localhost/zones",
+        headers={"X-API-Key": "invalid", "X-Forwarded-For": "203.0.113.9"},
+    )
+
+    assert _audit_record(caplog)["client_ip"] == "203.0.113.9"
+
+
+def test_middleware_logs_rightmost_untrusted_hop_of_forwarded_chain(caplog):
+    """A hop the client forged on the left must not win over the real one."""
+    proxied_app = ProxyHeadersMiddleware(app, trusted_hosts="testclient,10.0.0.7")
+    proxied_client = TestClient(proxied_app)
+
+    proxied_client.get(
+        "/api/v1/servers/localhost/zones",
+        headers={
+            "X-API-Key": "invalid",
+            # 198.51.100.5 is client-supplied and untrustworthy, 10.0.0.7 is our
+            # own proxy, so 203.0.113.9 is the first hop we can actually vouch for
+            "X-Forwarded-For": "198.51.100.5, 203.0.113.9, 10.0.0.7",
+        },
+    )
+
+    assert _audit_record(caplog)["client_ip"] == "203.0.113.9"
+
+
+def test_middleware_omits_client_ip_when_disabled(client, caplog, monkeypatch):
+    monkeypatch.setenv("AUDIT_LOG_CLIENT_IP", "false")
+
+    client.get(
+        "/api/v1/servers/localhost/zones",
+        headers={"X-API-Key": "invalid"},
+    )
+
+    audit = _audit_record(caplog)
+    assert "client_ip" not in audit
+    # the rest of the audit trail is untouched
+    assert audit["method"] == "GET"
+    assert "/zones" in audit["path"]
+
+
+def test_middleware_omits_client_ip_when_peer_unknown(caplog):
+    _asgi_get_without_client(app, "/api/v1/servers/localhost/zones")
+
+    assert "client_ip" not in _audit_record(caplog)


### PR DESCRIPTION
Audit records previously identified only the environment behind a token, so an operation could not be attributed to a caller. Add `client_ip`, reported next to the environment it belongs to in both the text and JSON formats.

The address comes from `request.client.host`, which uvicorn rewrites from `X-Forwarded-For` when the immediate peer is trusted. Pass `proxy_headers` and `forwarded_allow_ips` to `uvicorn.run()` explicitly rather than relying on the framework defaults, so the trust boundary is visible in our own code and cannot change silently on a dependency bump.

Client IPs are personal data, so `AUDIT_LOG_CLIENT_IP=false` omits the field while leaving the rest of the audit trail intact.

Document the reverse-proxy setup this depends on: the nginx headers, `FORWARDED_ALLOW_IPS`, why `*` is unsafe, and the edge-vs-chain `$proxy_add_x_forwarded_for` caveat.

Also make middleware_test.py set PROXY_CONFIG_PATH itself; it previously only passed because config_test.py sorts earlier and set it as a side effect, so the file failed when run alone.